### PR TITLE
ci: fix gh-pages deploy credential error

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,8 +40,10 @@ jobs:
 
       - name: Deploy
         run: |
-          git config --global user.name ${user_name}
-          git config --global user.email ${user_email}
+          git config --global user.name "${user_name}"
+          git config --global user.email "${user_email}"
+          git config --global credential.helper store
+          echo "https://${github_token}:x-oauth-basic@github.com" > ~/.git-credentials
           git remote set-url origin https://${github_token}@github.com/${repository}
           npm run deploy
         env:
@@ -49,6 +51,7 @@ jobs:
           user_email: "github-actions[bot]@users.noreply.github.com"
           github_token: ${{ secrets.GH_TOKEN }}
           repository: ${{ github.repository }}
+          GIT_TERMINAL_PROMPT: 0
           REACT_APP_FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
           REACT_APP_FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
           REACT_APP_FIREBASE_AUTH_DOMAIN: ${{ secrets.FIREBASE_AUTH_DOMAIN }}


### PR DESCRIPTION
gh-pages spawns git in non-interactive mode and cannot prompt for a password. Fix by writing the token to ~/.git-credentials via the store helper and disabling terminal prompts with GIT_TERMINAL_PROMPT=0.