### PR TITLE
ci: skip deploy on forks, bump to Node 24

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [24.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
@@ -39,6 +39,7 @@ jobs:
       - run: npm run build --if-present
 
       - name: Deploy
+        if: github.repository == 'THRALLab/starter_helpi'
         run: |
           git config --global user.name "${user_name}"
           git config --global user.email "${user_email}"


### PR DESCRIPTION
The deploy step was running on the fork (kush-patel1/LiveCue) which has no GH_TOKEN secret, causing auth failure. Added an if condition so the deploy only runs when github.repository == 'THRALLab/starter_helpi'.

Also bumped node-version to 24.x to clear the Node 20 deprecation warning before the forced cutover on June 16th.