### PR TITLE
ci: add workflow_dispatch trigger for manual deploys

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,7 @@ name: Node.js CI
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Allows the workflow to be triggered manually from the GitHub Actions tab without needing a push to main.