### PR TITLE
ci: bump actions to v4 to fix cache 400 error

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,13 +13,13 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [24.x]
+        node-version: [16.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"


### PR DESCRIPTION
actions/setup-node@v2 is incompatible with the current GitHub Actions cache service and returns a 400 error. Bumped checkout and setup-node to v4.