### PR TITLE
ci: restore credential fix and fork deploy guard

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,9 +39,12 @@ jobs:
       - run: npm run build --if-present
 
       - name: Deploy
+        if: github.repository == 'THRALLab/starter_helpi'
         run: |
-          git config --global user.name ${user_name}
-          git config --global user.email ${user_email}
+          git config --global user.name "${user_name}"
+          git config --global user.email "${user_email}"
+          git config --global credential.helper store
+          echo "https://${github_token}:x-oauth-basic@github.com" > ~/.git-credentials
           git remote set-url origin https://${github_token}@github.com/${repository}
           npm run deploy
         env:
@@ -49,6 +52,7 @@ jobs:
           user_email: "github-actions[bot]@users.noreply.github.com"
           github_token: ${{ secrets.GH_TOKEN }}
           repository: ${{ github.repository }}
+          GIT_TERMINAL_PROMPT: 0
           REACT_APP_FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
           REACT_APP_FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
           REACT_APP_FIREBASE_AUTH_DOMAIN: ${{ secrets.FIREBASE_AUTH_DOMAIN }}


### PR DESCRIPTION
Re-applies fixes that were lost in a revert:
- credential.helper store + ~/.git-credentials so gh-pages can auth
- GIT_TERMINAL_PROMPT=0 to prevent interactive password prompt in CI
- deploy if condition so forks without GH_TOKEN secret don't fail