### PR TITLE
ci: fix deploy condition to match actual repo (kush-patel1/LiveCue)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
       - run: npm run build --if-present
 
       - name: Deploy
-        if: github.repository == 'THRALLab/starter_helpi'
+        if: github.repository == 'kush-patel1/LiveCue'
         run: |
           git config --global user.name "${user_name}"
           git config --global user.email "${user_email}"


### PR DESCRIPTION
Deploy was being skipped because the if condition checked for THRALLab/starter_helpi but the workflow runs on kush-patel1/LiveCue.