### PR TITLE
feat: gate Stripe checkout behind auth — redirect to signup/login wit…

### DIFF
--- a/src/Pages/Landing Page/LandingPage.tsx
+++ b/src/Pages/Landing Page/LandingPage.tsx
@@ -2,8 +2,6 @@ import { useNavigate } from "react-router-dom";
 import "./LandingPage.css";
 import logo from "../../Assets/Logo/LIVECUE-Logo.png";
 
-const STRIPE_PRO_LINK = "https://buy.stripe.com/3cI9AVgIO6ng7qz2Ii18c02";
-const STRIPE_TEAM_LINK = "https://buy.stripe.com/6oU9AVdwC3b4h191Ee18c00";
 
 const scrollTo = (id: string) => {
   document.getElementById(id)?.scrollIntoView({ behavior: "smooth" });
@@ -283,7 +281,7 @@ function LandingPage() {
               <li>Drag-to-reorder</li>
               <li>Shareable live view</li>
             </ul>
-            <button className="btn-price btn-price-white" onClick={() => window.open(STRIPE_PRO_LINK, "_blank")}>
+            <button className="btn-price btn-price-white" onClick={() => navigate("/pricing")}>
               Start Pro
             </button>
           </div>
@@ -300,7 +298,7 @@ function LandingPage() {
               <li>AI Excel import (50/month)</li>
               <li>Priority support</li>
             </ul>
-            <button className="btn-price btn-price-outline" onClick={() => window.open(STRIPE_TEAM_LINK, "_blank")}>
+            <button className="btn-price btn-price-outline" onClick={() => navigate("/pricing")}>
               Start Team
             </button>
           </div>

--- a/src/Pages/Login Page/Login.tsx
+++ b/src/Pages/Login Page/Login.tsx
@@ -1,7 +1,7 @@
 import React, { FormEvent, useState } from "react";
 import "./Login.css";
 import { LoginPageProps } from "./LoginProps";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { CredentialLoadingScreen } from "../../Components/LoadingScreen/CredentialLoadingScreen";
 import { auth } from "../../Backend/firebase";
 import { signInWithEmailAndPassword } from "firebase/auth";
@@ -19,6 +19,13 @@ function mapFirebaseUserToAppUser(firebaseUser: FirebaseUser): User {
   };
 }
 
+const PAYMENT_LINKS: Record<string, string> = {
+  pro_monthly:  "https://buy.stripe.com/3cI9AVgIO6ng7qz2Ii18c02",
+  pro_annual:   "https://buy.stripe.com/cNi14p78edPI8uDciS18c03",
+  team_monthly: "https://buy.stripe.com/6oU9AVdwC3b4h191Ee18c00",
+  team_annual:  "https://buy.stripe.com/aFadRb0JQeTM7qzfv418c01",
+};
+
 function Login({ setUser }: LoginPageProps): React.JSX.Element {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -26,6 +33,7 @@ function Login({ setUser }: LoginPageProps): React.JSX.Element {
   const [passwordError, setPasswordError] = useState("");
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
 
   async function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -42,7 +50,12 @@ function Login({ setUser }: LoginPageProps): React.JSX.Element {
       const appUser = mapFirebaseUserToAppUser(credential.user);
       sessionStorage.setItem("CURRENT_USER", JSON.stringify(appUser));
       setUser(appUser);
-      navigate("/HomePage");
+      const planParam = searchParams.get("plan");
+      if (planParam && PAYMENT_LINKS[planParam]) {
+        window.location.href = PAYMENT_LINKS[planParam];
+      } else {
+        navigate("/HomePage");
+      }
     } catch (error: any) {
       setLoading(false);
       const code = error.code;
@@ -97,7 +110,7 @@ function Login({ setUser }: LoginPageProps): React.JSX.Element {
 
         <p className="auth-footer">
           Don't have an account?{' '}
-          <Link to="/signup" className="auth-link">Sign up</Link>
+          <Link to={searchParams.get("plan") ? `/signup?plan=${searchParams.get("plan")}` : "/signup"} className="auth-link">Sign up</Link>
         </p>
       </div>
     </div>

--- a/src/Pages/Pricing Page/PricingPage.tsx
+++ b/src/Pages/Pricing Page/PricingPage.tsx
@@ -45,7 +45,13 @@ function PricingPage() {
   const [checkoutLoading, setCheckoutLoading] = useState<PriceKey | null>(null);
   const plan = PLANS[billing];
 
+  const isLoggedIn = !!sessionStorage.getItem("CURRENT_USER");
+
   const handleCheckout = (priceKey: PriceKey) => {
+    if (!isLoggedIn) {
+      navigate(`/signup?plan=${priceKey}`);
+      return;
+    }
     setCheckoutLoading(priceKey);
     window.location.href = PAYMENT_LINKS[priceKey];
   };

--- a/src/Pages/SignUp/SignUp.tsx
+++ b/src/Pages/SignUp/SignUp.tsx
@@ -1,12 +1,19 @@
 import { FormEvent, useState } from "react";
 import { User } from "../../Interfaces/User/User";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { SignUpPageProps } from "./SignUpProps";
 import { auth, db, createUserWithEmailAndPassword, setDoc, doc } from "../../Backend/firebase";
 import { applyGrantIfExists } from "../../Services/PlanService/grantCheck";
 import { CredentialLoadingScreen } from "../../Components/LoadingScreen/CredentialLoadingScreen";
 import "../Login Page/Login.css";
 import "./SignUp.css";
+
+const PAYMENT_LINKS: Record<string, string> = {
+  pro_monthly:  "https://buy.stripe.com/3cI9AVgIO6ng7qz2Ii18c02",
+  pro_annual:   "https://buy.stripe.com/cNi14p78edPI8uDciS18c03",
+  team_monthly: "https://buy.stripe.com/6oU9AVdwC3b4h191Ee18c00",
+  team_annual:  "https://buy.stripe.com/aFadRb0JQeTM7qzfv418c01",
+};
 
 export function SignUp({ setUser }: SignUpPageProps): React.JSX.Element {
   const [firstName, setFirstName] = useState("");
@@ -17,6 +24,7 @@ export function SignUp({ setUser }: SignUpPageProps): React.JSX.Element {
   const [passwordError, setPasswordError] = useState("");
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
 
   async function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -38,7 +46,12 @@ export function SignUp({ setUser }: SignUpPageProps): React.JSX.Element {
       const userData: User = { id: credential.user.uid, firstName, lastName, email, password };
       setUser(userData);
       sessionStorage.setItem("CURRENT_USER", JSON.stringify(userData));
-      navigate("/HomePage");
+      const planParam = searchParams.get("plan");
+      if (planParam && PAYMENT_LINKS[planParam]) {
+        window.location.href = PAYMENT_LINKS[planParam];
+      } else {
+        navigate("/HomePage");
+      }
     } catch (error: any) {
       setLoading(false);
       if (error.code === "auth/email-already-in-use") {
@@ -119,7 +132,7 @@ export function SignUp({ setUser }: SignUpPageProps): React.JSX.Element {
 
         <p className="auth-footer">
           Already have an account?{' '}
-          <Link to="/login" className="auth-link">Sign in</Link>
+          <Link to={searchParams.get("plan") ? `/login?plan=${searchParams.get("plan")}` : "/login"} className="auth-link">Sign in</Link>
         </p>
       </div>
     </div>


### PR DESCRIPTION
…h plan param

Unauthenticated users clicking upgrade on pricing page or landing page are now sent to /signup?plan=<key>. After creating an account (or logging in), they are redirected straight to the correct Stripe payment link. The plan param is preserved if the user switches between signup and login.