### PR TITLE
feat: disable paid plan checkout with Coming Soon state

### DIFF
--- a/src/Pages/Login Page/Login.tsx
+++ b/src/Pages/Login Page/Login.tsx
@@ -8,7 +8,6 @@ import { signInWithEmailAndPassword } from "firebase/auth";
 import { applyGrantIfExists } from "../../Services/PlanService/grantCheck";
 import { User as FirebaseUser } from "firebase/auth";
 import { User } from "../../Interfaces/User/User";
-import { getPaymentLink } from "../../Config/stripeLinks";
 
 function mapFirebaseUserToAppUser(firebaseUser: FirebaseUser): User {
   return {
@@ -44,9 +43,9 @@ function Login({ setUser }: LoginPageProps): React.JSX.Element {
       const appUser = mapFirebaseUserToAppUser(credential.user);
       sessionStorage.setItem("CURRENT_USER", JSON.stringify(appUser));
       setUser(appUser);
-      const paymentUrl = getPaymentLink(searchParams.get("plan"));
-      if (paymentUrl) {
-        window.location.href = paymentUrl;
+      const redirect = searchParams.get("redirect");
+      if (redirect) {
+        navigate(redirect);
       } else {
         navigate("/HomePage");
       }
@@ -104,7 +103,16 @@ function Login({ setUser }: LoginPageProps): React.JSX.Element {
 
         <p className="auth-footer">
           Don't have an account?{' '}
-          <Link to={searchParams.get("plan") ? `/signup?plan=${searchParams.get("plan")}` : "/signup"} className="auth-link">Sign up</Link>
+          <Link
+            to={
+              searchParams.get("redirect")
+                ? `/signup?redirect=${encodeURIComponent(searchParams.get("redirect")!)}`
+                : searchParams.get("plan")
+                  ? `/signup?plan=${searchParams.get("plan")}`
+                  : "/signup"
+            }
+            className="auth-link"
+          >Sign up</Link>
         </p>
       </div>
     </div>

--- a/src/Pages/Pricing Page/PricingPage.css
+++ b/src/Pages/Pricing Page/PricingPage.css
@@ -283,6 +283,48 @@
   background: linear-gradient(135deg, var(--teal) 0%, #3d7080 100%);
   color: #fff;
 }
+.pp-card-btn--coming-soon {
+  opacity: 0.45;
+  cursor: not-allowed;
+  pointer-events: none;
+  letter-spacing: 0.04em;
+}
+.pp-card-btn--coming-soon:hover { opacity: 0.45; transform: none; }
+
+/* ── Coming soon banner ── */
+.pp-coming-soon-banner {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 20px;
+  padding: 10px 20px;
+  border: 1px solid rgba(87, 132, 147, 0.4);
+  border-radius: 30px;
+  background: rgba(87, 132, 147, 0.1);
+  color: var(--teal-light);
+  font-family: "Inter-Medium", sans-serif;
+  font-size: 13px;
+  letter-spacing: 0.02em;
+}
+.pp-coming-soon-dot {
+  width: 7px; height: 7px;
+  border-radius: 50%;
+  background: var(--teal-light);
+  box-shadow: 0 0 6px var(--teal-light);
+  flex-shrink: 0;
+  animation: pp-pulse 2s ease-in-out infinite;
+}
+@keyframes pp-pulse {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.4; }
+}
+.pp-coming-soon-label {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  text-align: center;
+  margin-top: 8px;
+  letter-spacing: 0.03em;
+}
 
 /* ── FAQ ── */
 .pp-faq {

--- a/src/Pages/Pricing Page/PricingPage.tsx
+++ b/src/Pages/Pricing Page/PricingPage.tsx
@@ -2,19 +2,15 @@ import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import "./PricingPage.css";
 import logo from "../../Assets/Logo/LIVECUE-Logo.png";
-import { PAYMENT_LINKS, PlanPriceKey } from "../../Config/stripeLinks";
-import { usePlan } from "../../Hooks/usePlan";
-
-type PriceKey = PlanPriceKey;
 
 const PLANS = {
   monthly: {
-    pro:  { price: "14", period: "per month",                 savings: "Save $48 with annual",   priceKey: "pro_monthly"  as PriceKey },
-    team: { price: "39", period: "per month",                 savings: "Save $119 with annual",  priceKey: "team_monthly" as PriceKey },
+    pro:  { price: "14", period: "per month",                 savings: "Save $48 with annual",   priceKey: "pro_monthly" },
+    team: { price: "39", period: "per month",                 savings: "Save $119 with annual",  priceKey: "team_monthly"},
   },
   annual: {
-    pro:  { price: "10", period: "per month, billed $120/yr", savings: "You're saving $48",      priceKey: "pro_annual"   as PriceKey },
-    team: { price: "29", period: "per month, billed $349/yr", savings: "You're saving $119",     priceKey: "team_annual"  as PriceKey },
+    pro:  { price: "10", period: "per month, billed $120/yr", savings: "You're saving $48",      priceKey: "pro_annual"  },
+    team: { price: "29", period: "per month, billed $349/yr", savings: "You're saving $119",     priceKey: "team_annual" },
   },
 };
 
@@ -37,25 +33,7 @@ const CROSS = (
 function PricingPage() {
   const navigate = useNavigate();
   const [billing, setBilling] = useState<"monthly" | "annual">("monthly");
-  const [checkoutLoading, setCheckoutLoading] = useState<PriceKey | null>(null);
   const plan = PLANS[billing];
-
-  const currentUser = JSON.parse(sessionStorage.getItem("CURRENT_USER") || "null");
-  const { plan: currentPlan } = usePlan(currentUser?.id ?? null);
-
-  const handleCheckout = (priceKey: PriceKey) => {
-    if (!currentUser?.id) {
-      navigate(`/signup?plan=${priceKey}`);
-      return;
-    }
-    // Prevent duplicate subscriptions — send existing subscribers to the portal
-    if (currentPlan === "pro" || currentPlan === "team") {
-      navigate("/settings");
-      return;
-    }
-    setCheckoutLoading(priceKey);
-    window.location.href = `${PAYMENT_LINKS[priceKey]}?client_reference_id=${currentUser.id}`;
-  };
 
   return (
     <div className="lp-root">
@@ -89,6 +67,10 @@ function PricingPage() {
         <p className="pp-hero-sub">
           No hidden fees. No long-term contracts. Start free and upgrade when you're ready.
         </p>
+        <div className="pp-coming-soon-banner">
+          <span className="pp-coming-soon-dot" />
+          Paid plans are coming soon — subscriptions are not yet available.
+        </div>
 
         {/* Billing toggle */}
         <div className="pp-toggle glass-card">
@@ -134,6 +116,7 @@ function PricingPage() {
             <button className="pp-card-btn pp-card-btn--outline" onClick={() => navigate("/signup")}>
               Get Started Free
             </button>
+            <div className="pp-coming-soon-label">Free plan always available</div>
           </div>
 
           {/* Pro (featured) */}
@@ -156,12 +139,8 @@ function PricingPage() {
                   <li key={f} className="pp-feat pp-feat--yes"><span className="pp-feat-icon pp-feat-icon--yes">{CHECK}</span>{f}</li>
                 ))}
               </ul>
-              <button
-                className="pp-card-btn pp-card-btn--primary"
-                onClick={() => handleCheckout(plan.pro.priceKey)}
-                disabled={checkoutLoading !== null}
-              >
-                {checkoutLoading === plan.pro.priceKey ? "Redirecting…" : "Start Pro"}
+              <button className="pp-card-btn pp-card-btn--primary pp-card-btn--coming-soon" disabled>
+                Coming Soon
               </button>
             </div>
           </div>
@@ -184,12 +163,8 @@ function PricingPage() {
                 <li key={f} className="pp-feat pp-feat--yes"><span className="pp-feat-icon pp-feat-icon--yes">{CHECK}</span>{f}</li>
               ))}
             </ul>
-            <button
-              className="pp-card-btn pp-card-btn--teal"
-              onClick={() => handleCheckout(plan.team.priceKey)}
-              disabled={checkoutLoading !== null}
-            >
-              {checkoutLoading === plan.team.priceKey ? "Redirecting…" : "Start Team"}
+            <button className="pp-card-btn pp-card-btn--teal pp-card-btn--coming-soon" disabled>
+              Coming Soon
             </button>
           </div>
 

--- a/src/Pages/SignUp/SignUp.tsx
+++ b/src/Pages/SignUp/SignUp.tsx
@@ -7,7 +7,6 @@ import { applyGrantIfExists } from "../../Services/PlanService/grantCheck";
 import { CredentialLoadingScreen } from "../../Components/LoadingScreen/CredentialLoadingScreen";
 import "../Login Page/Login.css";
 import "./SignUp.css";
-import { getPaymentLink } from "../../Config/stripeLinks";
 
 export function SignUp({ setUser }: SignUpPageProps): React.JSX.Element {
   const [firstName, setFirstName] = useState("");
@@ -40,9 +39,9 @@ export function SignUp({ setUser }: SignUpPageProps): React.JSX.Element {
       const userData: User = { id: credential.user.uid, firstName, lastName, email, password };
       setUser(userData);
       sessionStorage.setItem("CURRENT_USER", JSON.stringify(userData));
-      const paymentUrl = getPaymentLink(searchParams.get("plan"));
-      if (paymentUrl) {
-        window.location.href = paymentUrl;
+      const redirect = searchParams.get("redirect");
+      if (redirect) {
+        navigate(redirect);
       } else {
         navigate("/HomePage");
       }
@@ -126,7 +125,16 @@ export function SignUp({ setUser }: SignUpPageProps): React.JSX.Element {
 
         <p className="auth-footer">
           Already have an account?{' '}
-          <Link to={searchParams.get("plan") ? `/login?plan=${searchParams.get("plan")}` : "/login"} className="auth-link">Sign in</Link>
+          <Link
+            to={
+              searchParams.get("redirect")
+                ? `/login?redirect=${encodeURIComponent(searchParams.get("redirect")!)}`
+                : searchParams.get("plan")
+                  ? `/login?plan=${searchParams.get("plan")}`
+                  : "/login"
+            }
+            className="auth-link"
+          >Sign in</Link>
         </p>
       </div>
     </div>


### PR DESCRIPTION
- Add pulsing Coming Soon banner on pricing page hero
- Disable Pro and Team checkout buttons (pointer-events: none, not-allowed)
- Remove all paths to Stripe: checkout redirect stripped from Login and SignUp post-auth flows; getPaymentLink imports removed
- Free plan signup button remains active