### PR TITLE
fix: time-of-day calculations and remove cue cascade

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>LiveCue</title>
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css"

--- a/src/Pages/Admin Page/AdminPage.tsx
+++ b/src/Pages/Admin Page/AdminPage.tsx
@@ -188,20 +188,9 @@ function AdminPage({ projects }: AdminPageProps) {
 
   const handleNextCue = async () => {
     if (liveIdx === -1 || liveIdx >= sorted.length - 1) return;
-    const ts = new Date().toISOString();
     const next = sorted[liveIdx + 1];
     await updateDoc(doc(db, 'cues', sorted[liveIdx].id), { isLive: false });
-    await updateDoc(doc(db, 'cues', next.id), { isLive: true, actualStartTime: ts });
-    const drift = Math.round((new Date(ts).getTime() - new Date(next.startTime).getTime()) / 60000);
-    if (Math.abs(drift) >= 2 && liveIdx + 1 < sorted.length - 1) {
-      const driftMs = drift * 60000;
-      await Promise.all(sorted.slice(liveIdx + 2).map(cue =>
-        updateDoc(doc(db, 'cues', cue.id), {
-          startTime: new Date(new Date(cue.startTime).getTime() + driftMs).toISOString(),
-          endTime:   new Date(new Date(cue.endTime).getTime()   + driftMs).toISOString(),
-        })
-      ));
-    }
+    await updateDoc(doc(db, 'cues', next.id), { isLive: true, actualStartTime: new Date().toISOString() });
   };
 
   const handlePrevCue = async () => {

--- a/src/Pages/Admin Page/AdminPage.tsx
+++ b/src/Pages/Admin Page/AdminPage.tsx
@@ -12,11 +12,14 @@ interface AdminPageProps {
   projects: Project[];
 }
 
+function todSecs(iso: string): number {
+  const d = new Date(iso);
+  return d.getHours() * 3600 + d.getMinutes() * 60 + d.getSeconds();
+}
+
 function getDriftMinutes(cue: Cue): number | null {
   if (!cue.actualStartTime) return null;
-  return Math.round(
-    (new Date(cue.actualStartTime).getTime() - new Date(cue.startTime).getTime()) / 60000
-  );
+  return Math.round((todSecs(cue.actualStartTime) - todSecs(cue.startTime)) / 60);
 }
 
 function mapCue(data: any, id: string): Cue {
@@ -43,7 +46,7 @@ function fmtTime(iso: string) {
 }
 
 function fmtDuration(startIso: string, endIso: string) {
-  const mins = Math.round((new Date(endIso).getTime() - new Date(startIso).getTime()) / 60000);
+  const mins = Math.round((todSecs(endIso) - todSecs(startIso)) / 60);
   if (mins <= 0) return '—';
   if (mins < 60) return `${mins}m`;
   const h = Math.floor(mins / 60);
@@ -58,11 +61,11 @@ function fmtElapsed(seconds: number) {
   return `${String(h).padStart(2,'0')}:${String(m).padStart(2,'0')}:${String(s).padStart(2,'0')}`;
 }
 
-function fmtCountdown(ms: number) {
-  const abs = Math.abs(ms);
-  const s = Math.floor(abs / 1000) % 60;
-  const m = Math.floor(abs / 60000) % 60;
-  const h = Math.floor(abs / 3600000);
+function fmtCountdown(secs: number) {
+  const abs = Math.abs(Math.round(secs));
+  const s = abs % 60;
+  const m = Math.floor(abs / 60) % 60;
+  const h = Math.floor(abs / 3600);
   if (h > 0) return `${String(h).padStart(2,'0')}:${String(m).padStart(2,'0')}:${String(s).padStart(2,'0')}`;
   return `${String(m).padStart(2,'0')}:${String(s).padStart(2,'0')}`;
 }
@@ -161,18 +164,14 @@ function AdminPage({ projects }: AdminPageProps) {
   const nextCue = liveIdx >= 0 ? sorted[liveIdx + 1] : sorted[0];
   const globalDrift = liveCue ? getDriftMinutes(liveCue) : null;
 
-  const nextCueMs = nextCue
-    ? new Date(nextCue.startTime).getTime() - now.getTime()
-    : null;
+  const ns = now.getHours() * 3600 + now.getMinutes() * 60 + now.getSeconds();
 
-  const liveElapsedMs = liveCue
-    ? now.getTime() - new Date(liveCue.startTime).getTime()
-    : null;
-  const liveDurationMs = liveCue
-    ? new Date(liveCue.endTime).getTime() - new Date(liveCue.startTime).getTime()
-    : null;
-  const liveProgressPct = (liveElapsedMs != null && liveDurationMs && liveDurationMs > 0)
-    ? Math.min(100, Math.max(0, (liveElapsedMs / liveDurationMs) * 100))
+  const nextCueSecs = nextCue ? todSecs(nextCue.startTime) - ns : null;
+
+  const liveElapsedSecs = liveCue ? ns - todSecs(liveCue.startTime) : null;
+  const liveDurationSecs = liveCue ? todSecs(liveCue.endTime) - todSecs(liveCue.startTime) : null;
+  const liveProgressPct = (liveElapsedSecs != null && liveDurationSecs && liveDurationSecs > 0)
+    ? Math.min(100, Math.max(0, (liveElapsedSecs / liveDurationSecs) * 100))
     : 0;
 
   const toggleLive = async () => {
@@ -361,21 +360,21 @@ function AdminPage({ projects }: AdminPageProps) {
                     <span className="adm-readout-key">NOW</span>
                     <span className="adm-readout-val">{liveCue.cueNumber}. {liveCue.title}</span>
                   </div>
-                  {liveElapsedMs != null && (
+                  {liveElapsedSecs != null && (
                     <div className="adm-readout-row">
                       <span className="adm-readout-key">ELAPSED</span>
-                      <span className="adm-readout-val adm-mono">{fmtCountdown(liveElapsedMs)}</span>
+                      <span className="adm-readout-val adm-mono">{fmtCountdown(liveElapsedSecs)}</span>
                     </div>
                   )}
                 </div>
               )}
 
-              {nextCue && nextCueMs != null && (
+              {nextCue && nextCueSecs != null && (
                 <div className="adm-next-cue-block">
                   <div className="adm-next-label">NEXT UP</div>
                   <div className="adm-next-title">{nextCue.cueNumber}. {nextCue.title}</div>
-                  <div className={`adm-next-countdown ${nextCueMs < 60000 ? 'adm-next-countdown--urgent' : ''}`}>
-                    {nextCueMs > 0 ? `in ${fmtCountdown(nextCueMs)}` : `${fmtCountdown(Math.abs(nextCueMs))} ago`}
+                  <div className={`adm-next-countdown ${nextCueSecs < 60 ? 'adm-next-countdown--urgent' : ''}`}>
+                    {nextCueSecs > 0 ? `in ${fmtCountdown(nextCueSecs)}` : `${fmtCountdown(Math.abs(nextCueSecs))} ago`}
                   </div>
                 </div>
               )}

--- a/src/Pages/Cue Input/CueInput.tsx
+++ b/src/Pages/Cue Input/CueInput.tsx
@@ -74,7 +74,7 @@ function SortableFieldHeader({ field, onRemove }: {
   );
 }
 
-function cascadeTimes(cues: Cue[]): Cue[] {
+/*function cascadeTimes(cues: Cue[]): Cue[] {
   const result = [...cues];
   for (let i = 1; i < result.length; i++) {
     const prev = result[i - 1];
@@ -85,7 +85,7 @@ function cascadeTimes(cues: Cue[]): Cue[] {
     result[i] = { ...curr, startTime: newStart.toISOString(), endTime: newEnd.toISOString() };
   }
   return result;
-}
+}*/
 
 function SortableCueRow({
   cue, index, fields, isLast, dragEnabled, onInputChange, onTimeChange, onDelete,
@@ -321,11 +321,14 @@ function CueInput({ projects }: CueInputProps) {
     setSaveStatus('saving');
     const updated = [...cues];
     updated[index] = { ...updated[index], [field]: fromTimeInput(timeStr, updated[index][field]) };
-    const cascaded = cascadeTimes(updated);
-    setCues(cascaded);
-    cascaded.slice(index).forEach((c) => debouncedUpdate(c));
-    // Keep homepage start time in sync when first cue's start changes
-    if (index === 0 && field === 'startTime') syncProjectMeta(cascaded);
+    // Keep the next cue's start time in sync with this cue's end time
+    if (field === 'endTime' && index + 1 < updated.length) {
+      updated[index + 1] = { ...updated[index + 1], startTime: updated[index].endTime };
+      debouncedUpdate(updated[index + 1]);
+    }
+    setCues(updated);
+    debouncedUpdate(updated[index]);
+    if (index === 0 && field === 'startTime') syncProjectMeta(updated);
   };
 
   const handleDragEnd = async (event: DragEndEvent) => {
@@ -336,14 +339,12 @@ function CueInput({ projects }: CueInputProps) {
     const reordered = arrayMove(cues, oldIndex, newIndex).map((c, i) => ({
       ...c, cueNumber: i + 1, isLive: i === 0,
     }));
-    const cascaded = cascadeTimes(reordered);
-    setCues(cascaded);
-    syncProjectMeta(cascaded);
+    setCues(reordered);
+    syncProjectMeta(reordered);
     await Promise.all(
-      cascaded.map((c) =>
+      reordered.map((c) =>
         updateDoc(doc(db, 'cues', c.id), {
-          cueNumber: c.cueNumber, startTime: c.startTime,
-          endTime: c.endTime, isLive: c.isLive,
+          cueNumber: c.cueNumber, isLive: c.isLive,
         })
       )
     );

--- a/src/Pages/Live Cue Sheet/LiveCueSheet.tsx
+++ b/src/Pages/Live Cue Sheet/LiveCueSheet.tsx
@@ -13,12 +13,23 @@ interface LiveCueSheetProps {
   projects: Project[];
 }
 
+// Returns seconds-since-midnight for a given ISO string, ignoring the date portion
+function timeOfDaySecs(iso: string): number {
+  const d = new Date(iso);
+  return d.getHours() * 3600 + d.getMinutes() * 60 + d.getSeconds();
+}
+
+// Difference in seconds between two ISO times using only their time-of-day (a - b)
+function todDiffSecs(aIso: string, bIso: string): number {
+  return timeOfDaySecs(aIso) - timeOfDaySecs(bIso);
+}
+
 function fmtTime(iso: string) {
   return new Date(iso).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit', hour12: true });
 }
 
 function fmtDuration(startIso: string, endIso: string) {
-  const mins = Math.round((new Date(endIso).getTime() - new Date(startIso).getTime()) / 60000);
+  const mins = Math.round(todDiffSecs(endIso, startIso) / 60);
   if (mins <= 0) return '—';
   if (mins < 60) return `${mins}m`;
   const h = Math.floor(mins / 60);
@@ -26,14 +37,17 @@ function fmtDuration(startIso: string, endIso: string) {
   return m === 0 ? `${h}h` : `${h}h ${m}m`;
 }
 
-function fmtCountdown(ms: number): string {
-  const abs = Math.abs(ms);
-  const totalSecs = Math.floor(abs / 1000);
-  const h = Math.floor(totalSecs / 3600);
-  const m = Math.floor((totalSecs % 3600) / 60);
-  const s = totalSecs % 60;
+function fmtCountdown(absSecs: number): string {
+  const h = Math.floor(absSecs / 3600);
+  const m = Math.floor((absSecs % 3600) / 60);
+  const s = absSecs % 60;
   if (h > 0) return `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
   return `${m}:${String(s).padStart(2, '0')}`;
+}
+
+// Seconds since midnight for the live clock
+function nowSecs(now: Date): number {
+  return now.getHours() * 3600 + now.getMinutes() * 60 + now.getSeconds();
 }
 
 const BROADCAST_EXPIRY_MS = 2 * 60 * 1000; // 2 minutes
@@ -142,9 +156,10 @@ function LiveCueSheet({ projects }: LiveCueSheetProps) {
   const sorted = [...cues].sort((a, b) => a.cueNumber - b.cueNumber);
   const liveIndex = sorted.findIndex(c => c.isLive);
   const liveCue = liveIndex >= 0 ? sorted[liveIndex] : null;
+  const ns = nowSecs(now);
   const nextCue = liveIndex >= 0
     ? sorted[liveIndex + 1]
-    : sorted.find(c => new Date(c.startTime) > now);
+    : sorted.find(c => timeOfDaySecs(c.startTime) > ns);
 
   if (loading) return <LoadingScreen />;
 
@@ -194,14 +209,14 @@ function LiveCueSheet({ projects }: LiveCueSheetProps) {
           <span className="lcs-status-title">{liveCue.cueNumber} — {liveCue.title}</span>
           <span className="lcs-status-sep">·</span>
           <span className="lcs-status-meta">
-            +{fmtCountdown(Math.max(0, now.getTime() - new Date(liveCue.startTime).getTime()))} elapsed
+            +{fmtCountdown(Math.max(0, ns - timeOfDaySecs(liveCue.startTime)))} elapsed
           </span>
           {nextCue && (
             <>
               <span className="lcs-status-sep">·</span>
               <span className="lcs-status-meta">
                 Up next: <strong>{nextCue.title}</strong>
-                {' '}in {fmtCountdown(Math.abs(new Date(nextCue.startTime).getTime() - now.getTime()))}
+                {' '}in {fmtCountdown(Math.max(0, timeOfDaySecs(nextCue.startTime) - ns))}
               </span>
             </>
           )}
@@ -212,7 +227,7 @@ function LiveCueSheet({ projects }: LiveCueSheetProps) {
           <span className="lcs-status-title">{nextCue.title}</span>
           <span className="lcs-status-sep">·</span>
           <span className="lcs-status-meta">
-            starts in {fmtCountdown(Math.max(0, new Date(nextCue.startTime).getTime() - now.getTime()))}
+            starts in {fmtCountdown(Math.max(0, timeOfDaySecs(nextCue.startTime) - ns))}
           </span>
         </div>
       ) : null}


### PR DESCRIPTION
## Summary
- Fixed broken time displays in AdminPage and LiveCueSheet: all elapsed/countdown calculations used full epoch timestamps so if cue start/end times had an old date in Firestore the numbers were wildly off. Now all comparisons use time-of-day only.
- Removed cue time cascade in CueInput: editing a cue no longer overwrites every subsequent cue. Changing endTime propagates only to the next cue startTime.
- Drag-to-reorder no longer shifts times: only cueNumber and isLive are updated on reorder.

## Test plan
- [ ] Admin page during live show: elapsed timer and next cue countdown show correct minutes/seconds
- [ ] LiveCueSheet: elapsed and up-next countdown match the wall clock
- [ ] CueInput: editing a cue end time only updates the next cue start time
- [ ] Drag reorder: times stay as set

Generated with Claude Code