### PR TITLE
fix: welcome modal shows once per account, not every login

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -57,7 +57,7 @@ service cloud.firestore {
     // (plan, billing, teamId) is admin-SDK-only. Constraining the whole doc to
     // this set also blocks arbitrary/oversized junk from being stored.
     function isProfileOnly(keys) {
-      return keys.hasOnly(['firstName', 'lastName', 'email', 'acceptedTermsAt']);
+      return keys.hasOnly(['firstName', 'lastName', 'email', 'acceptedTermsAt', 'welcomedAt']);
     }
 
     // Users can read their own document and write profile fields only.

--- a/src/Pages/Home Page/HomePage.tsx
+++ b/src/Pages/Home Page/HomePage.tsx
@@ -5,7 +5,8 @@ import { LoadingScreen } from '../../Components/LoadingScreen/LoadingScreen';
 import './HomePage.css';
 import logo from '../../Assets/Logo/LIVECUE-Logo.png';
 import { Project } from '../../Interfaces/Project/Project';
-import { db, collection, addDoc, getDocs, query, where, auth, doc, deleteDoc, onSnapshot } from '../../Backend/firebase';
+import { db, collection, addDoc, getDocs, query, where, auth, doc, deleteDoc, onSnapshot, updateDoc } from '../../Backend/firebase';
+import { getDoc } from 'firebase/firestore';
 import { User } from '../../Interfaces/User/User';
 import { User as FirebaseUser, signOut } from 'firebase/auth';
 import { onAuthStateChanged } from 'firebase/auth';
@@ -64,19 +65,25 @@ const HomePage: React.FC<HomePageProps> = ({ user, projects, setProjects, setUse
   const { plan, canCreateProject, teamId, isTeamOwner } = usePlan(user?.id);
   const isTeamMember = !!teamId && !isTeamOwner;
 
-  // First-run welcome — shown once per user (keyed by uid in localStorage).
+  // First-run welcome — shown exactly once per account, ever. The flag lives on
+  // the user's Firestore doc (not localStorage, which is per-browser), and is
+  // written the moment the modal is shown so it never reappears — even across
+  // devices or if the user navigates away without closing it.
   useEffect(() => {
     const uid = auth.currentUser?.uid;
     if (!uid) return;
-    const key = `livecue_welcomed_${uid}`;
-    if (!localStorage.getItem(key)) setShowWelcome(true);
+    let active = true;
+    getDoc(doc(db, 'users', uid))
+      .then((snap) => {
+        if (!active || !snap.exists() || snap.data()?.welcomedAt) return;
+        setShowWelcome(true);
+        updateDoc(doc(db, 'users', uid), { welcomedAt: new Date().toISOString() }).catch(() => {});
+      })
+      .catch(() => {});
+    return () => { active = false; };
   }, [user?.id]);
 
-  const dismissWelcome = () => {
-    const uid = auth.currentUser?.uid;
-    if (uid) localStorage.setItem(`livecue_welcomed_${uid}`, '1');
-    setShowWelcome(false);
-  };
+  const dismissWelcome = () => setShowWelcome(false);
   const [loading, setLoading] = useState(true);
   const [showModal, setShowModal] = useState(false);
   const [showWelcome, setShowWelcome] = useState(false);


### PR DESCRIPTION
Was gated on localStorage (per-browser, and only written on dismiss), so it reappeared on new browsers/incognito/cache-clears or if the user navigated away without closing it. Now gated on a welcomedAt flag stored on the user's Firestore doc, written the moment the modal is shown — truly once per account, across all devices.